### PR TITLE
Feat 재 로그인 로직 구현

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "nodemon": "^3.1.14"
       },
       "devDependencies": {
+        "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "^9.0.10",
@@ -207,6 +208,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cors": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.19.3",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",
         "dotenv": "^17.4.1",
         "express": "^5.2.1",
@@ -638,6 +639,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node dist/app.js",
     "build": "tsc",
-    "dev": "nodemon --exec ts-node src/app.ts"
+    "dev": "nodemon --exec ts-node src/app.ts",
+    "dev-kill" : "npx kill-port 3000"
   },
   "keywords": [],
   "author": "",

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/app.js",
     "build": "tsc",
     "dev": "nodemon --exec ts-node src/app.ts",
-    "dev-kill" : "npx kill-port 3000"
+    "dev-kill": "npx kill-port 3000"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +16,7 @@
   "type": "commonjs",
   "dependencies": {
     "@prisma/client": "^6.19.3",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
     "dotenv": "^17.4.1",
     "express": "^5.2.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "nodemon": "^3.1.14"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,8 +2,10 @@ import express from  'express';
 import type {Request, Response} from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
+import cookieParser from 'cookie-parser';
 import user_router from './routes/user.routes';
 import auth_router from './routes/auth.routes';
+
 
 dotenv.config();
 
@@ -16,6 +18,7 @@ app.use(cors({
 }));
 app.use(express.json());
 app.use(express.urlencoded({extended : true}));
+app.use(cookieParser());
 
 // 기본 라우트, 서버를 헬스 체크 합니다.
 app.get('/', (req: Request, res: Response) => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -10,7 +10,10 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.use(cors());
+app.use(cors({
+  origin : 'http://localhost:5173', //프론트엔드 주소
+  credentials : true, //쿠키를 포함하여 요청을 보냄
+}));
 app.use(express.json());
 app.use(express.urlencoded({extended : true}));
 

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -19,6 +19,7 @@ auth_router.get('/check', async(req, res)=>{
     console.log("Received request to check authentication status");
 
     const token = req.cookies.app_token;
+    console.log("Received token from cookies:", req.cookies);
 
     if(!token){
         return res.status(401).json({ error : '인증 토큰이 없습니다.' });

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,17 +1,58 @@
-import Routes, { CookieOptions } from 'express';
+import Routes, { CookieOptions, Router } from 'express';
 import jwt from 'jsonwebtoken';
 import { Prisma, PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
-const auth_router = Routes();
+const auth_router = Router();
 
-auth_router.get('/',(req, res)=>{
-    res.json({ message: 'Auth route is working' });
+// api/auth
+auth_router.get('/', (req, res)=>{
+    res.json({ message: 'Auth route is working!' });
 })
 
 
-//http:localhost:3030/api/auth/github
+
+//  api/auth/check
+auth_router.get('/check', async(req, res)=>{
+    
+    console.log("Received request to check authentication status");
+
+    const token = req.cookies.app_token;
+
+    if(!token){
+        return res.status(401).json({ error : '인증 토큰이 없습니다.' });
+    }
+
+    try{
+        //토큰 디코딩
+        const decoded = jwt.verify(token, process.env.JWT_SECRET!);
+
+        //디코딩된 토큰에서 사용자 정보 추출
+        const { userId, githubId } = decoded as { userId : number, githubId : number };
+        //DB에서 사용자 정보 조회
+        const user = await prisma.user.findUnique({
+            where : {
+                id : userId,
+                githubId : githubId,
+            }
+        });
+
+        if(!user){
+            return res.status(404).json({ error : '사용자를 찾을 수 없습니다.' });
+        }
+       
+        res.status(200).json({
+            success : true
+        })
+
+    }catch(error){
+        console.error("Error : Token verification error", error);
+        return res.status(401).json({ error : '유효하지 않은 토큰입니다.' });
+    }
+})
+
+// api/auth/github
 auth_router.post('/github', async (req, res)=>{
     //Express는 응답을 한번만 보낼 수 있음. 조심하셈
     //res.json({ message: 'GitHub authentication endpoint' });
@@ -123,13 +164,13 @@ auth_router.post('/github', async (req, res)=>{
     }
     catch(error){
         console.log("Error : Github authentication error", error);
-         res.status(500).json({error : '인증 실패'});   
+        res.status(500).json({error : '인증 실패'});   
     }
 } )
 
 
 auth_router.use((req, res) =>{
-    res.status(404).json({ error: 'Not Found' });
+    res.status(404).json({ error: 'Not Found zzz' });
 })
 
 export default auth_router;

--- a/frontend/app/routes/auth/callback.tsx
+++ b/frontend/app/routes/auth/callback.tsx
@@ -27,7 +27,8 @@ export default function Callback() {
                     headers : {
                         'Content-Type' : 'application/json'
                     },
-                    body : JSON.stringify({code})
+                    body : JSON.stringify({code}),
+                    credentials : 'include'
                 })
 
                 if(response.ok){

--- a/frontend/app/routes/auth/callback.tsx
+++ b/frontend/app/routes/auth/callback.tsx
@@ -55,4 +55,9 @@ export default function Callback() {
 
     },[])
 
+    return(
+        <div className = "flex justify-center items-center h-screen">
+            <h1>로딩 중...</h1>
+        </div>
+    )
 }

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "react-router";
+import { redirect, useNavigate } from "react-router";
 import type { Route } from "./+types/home";
 import { Github } from "~/icons/Github";
 import type { StrictGithubOAuthParams } from "~/type/GithubOAuth";
@@ -41,10 +41,10 @@ export default function Home() {
   const [loginCheckState, setLoginCheckState] = useState(false);
   const ID =  import.meta.env.VITE_GITHUB_CLIENT_ID;
   const URL = import.meta.env.VITE_GITHUB_CALLBACK_URL;
+  const navigate = useNavigate();
   console.log("ID, URL " ,ID, URL);
 
-
-
+  
   useEffect(()=>{
     const checkRoute = async()=>{
       try{
@@ -54,7 +54,6 @@ export default function Home() {
         
          if(res.ok){
             const data = await res.json();
-            setLoginCheckState(true);
             console.log("Auth route response:", data);
          }
         
@@ -74,16 +73,19 @@ export default function Home() {
 
          if(res.ok){
             const data : CommonResponse = await res.json();
-            setLoginCheckState(true);
             console.log("Login check response:", data);
+            if('success' in data && data.success){
+              navigate('/dashboard');
+            }
          }
       }
       catch(error : unknown){
         console.error("Error : Token verification error", error);
+        setLoginCheckState(true);
       }
     } 
 
-    //checkLogin();
+    checkLogin();
 
   }, [])
  

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -2,6 +2,7 @@ import { redirect } from "react-router";
 import type { Route } from "./+types/home";
 import { Github } from "~/icons/Github";
 import type { StrictGithubOAuthParams } from "~/type/GithubOAuth";
+import { useEffect, useState } from "react";
 
 export function meta({}: Route.MetaArgs) {
   return [
@@ -34,26 +35,83 @@ const handleOAuthLogin = (ID: string, URL: string) => {
 
 };
 
+type CommonResponse = { success : boolean;} | { error : string; }
+
 export default function Home() {
+  const [loginCheckState, setLoginCheckState] = useState(false);
   const ID =  import.meta.env.VITE_GITHUB_CLIENT_ID;
   const URL = import.meta.env.VITE_GITHUB_CALLBACK_URL;
   console.log("ID, URL " ,ID, URL);
 
+
+
+  useEffect(()=>{
+    const checkRoute = async()=>{
+      try{
+        const res = await fetch('http://localhost:3000/api/auth',{
+           method : 'GET',
+         })
+        
+         if(res.ok){
+            const data = await res.json();
+            setLoginCheckState(true);
+            console.log("Auth route response:", data);
+         }
+        
+      }catch(error){
+        console.error("Error : Auth route check error", error);
+      }
+    }
+
+    checkRoute();
+
+    const checkLogin = async ()=>{
+      try{
+         const res = await fetch('http://localhost:3000/api/auth/check',{
+            method : 'GET',
+            credentials : 'include' // 쿠키를 포함하여 요청을 보냄
+         })
+
+         if(res.ok){
+            const data : CommonResponse = await res.json();
+            setLoginCheckState(true);
+            console.log("Login check response:", data);
+         }
+      }
+      catch(error : unknown){
+        console.error("Error : Token verification error", error);
+      }
+    } 
+
+    //checkLogin();
+
+  }, [])
+ 
+
+
   return <>
-  <div className = "flex flex-col items-center justify-center h-screen gap-4">
-    <span className = "text-4xl font-semibold">GitHub dashBoard</span>
-    <button 
-      className = {`border p-1 rounded-full 
-        hover:cursor-pointer hover:bg-gray-300 
-        transition-colors duration-150`}
-      onClick={()=>{
-        handleOAuthLogin(ID, URL);
-    }}>
-      <Github 
-        width={50}
-        height={50}
-      />
-    </button>
-  </div>
-  </>;
+    {loginCheckState ? (
+      <div className = "flex flex-col items-center justify-center h-screen gap-4">
+        <span className = "text-4xl font-semibold">GitHub dashBoard</span>
+        <button 
+          className = {`border p-1 rounded-full 
+            hover:cursor-pointer hover:bg-gray-300 
+            transition-colors duration-150`}
+          onClick={()=>{
+            handleOAuthLogin(ID, URL);
+        }}>
+          <Github 
+            width={50}
+            height={50}
+          />
+        </button>
+      </div>
+    ): 
+      <div className = "flex justify-center items-center h-screen">
+        <h1>로딩 중...</h1>
+      </div>
+    }
+
+
+    </>;
 }

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -44,7 +44,7 @@ export default function Home() {
   const navigate = useNavigate();
   console.log("ID, URL " ,ID, URL);
 
-  
+
   useEffect(()=>{
     const checkRoute = async()=>{
       try{
@@ -77,6 +77,9 @@ export default function Home() {
             if('success' in data && data.success){
               navigate('/dashboard');
             }
+         }
+         else{
+              throw new Error("Unauthorized");
          }
       }
       catch(error : unknown){


### PR DESCRIPTION
Closed #3 

### 백엔드 구현
- 프론트 개발서버에 대한 cors crediential 추가
- 로그인 검증 로직 추가 : api/auth/check

### 프론트엔드 구현
- 이미 로그인 해있을 시 대시보드로 리다이렉트 하는 로직
- 로그인 검증 중 loading UX 추가

### 의존성
- cookie-parser 설치

### 그 외
- 백엔드 : 프로세스 죽이기 명령어 추가